### PR TITLE
Add link to the spellcheck instructions to wiki

### DIFF
--- a/user_resources.md
+++ b/user_resources.md
@@ -18,6 +18,8 @@ Please submit a [PR to ungoogled-chromium-wiki](//github.com/ungoogled-software/
 
 * [chromium-web-store](https://github.com/NeverDecaf/chromium-web-store) - Check and/or install updates to CRX-based extensions (i.e. not exclusively from the Chrome Web Store). It supports optional automatic updates. This is an extension-based implementation of [Issue #285](https://github.com/Eloston/ungoogled-chromium/issues/285).
 
+* [dictionaries to enable spellcheck](https://github.com/Eloston/ungoogled-chromium/issues/188#issuecomment-643665850) - General instructions for how to add spellcheck support.
+
 # Disable WebAssembly
 
 *(Suggested in [#578](//github.com/Eloston/ungoogled-chromium/issues/578))*


### PR DESCRIPTION
Perhaps this isn't the best place to put this link, but I think it should be included somewhere.